### PR TITLE
plan id should be unique

### DIFF
--- a/broker/data/catalog.json
+++ b/broker/data/catalog.json
@@ -5,7 +5,7 @@
     "description": "Provides the ability to cause chaos on bound application instances",
     "bindable": true,
     "plans": [{
-      "id": "default",
+      "id": "62d4a872-2582-3215-7960-6419heck852j",
       "name": "default",
       "description": "The default and only plan",
       "metadata": {


### PR DESCRIPTION
Got an error when deploying because we already had a plan with "default" id.
